### PR TITLE
Correct examples of requiring files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can find help about how to rename here :
   "parcel-namer-functional" : [
     {
       "type" : "require",
-      "module" : "renamer.js", // relative to package.json
+      "file" : "renamer.js", // relative to package.json
       "function" : "pleaseRename"
     }
   ]
@@ -125,7 +125,7 @@ To fail silently, add this property to `"require"` or `"global"` in `package.jso
     },
     {
       "type" : "require",
-      "module" : "thisFileDoesNotExists.js",
+      "file" : "thisFileDoesNotExists.js",
       "function" : "thisFunctionDoesNotExists",
       "fail" : false
     }


### PR DESCRIPTION
Thanks for sharing this. Just noticed that some examples use `module` where the plugin uses `file`:

https://github.com/zouloux/parcel-namer-functional/blob/a84cd062ea425ad823f6c96f201598d1b748db0e/FunctionalNamer.js#L121